### PR TITLE
Update link in ViewScheduledSqlJobs.ascx

### DIFF
--- a/ScheduledJobs/ViewScheduledSqlJobs.ascx
+++ b/ScheduledJobs/ViewScheduledSqlJobs.ascx
@@ -97,5 +97,5 @@
 </asp:Panel>
 
 <p class="Normal">
-<a href="http://www.iowacomputergurus.com/Products/Open-Source" target="_blank" class="CommandButton">Scheduled SQL Jobs is a free module provided by IowaComputerGurus Inc. (Donations Appreciated)</a>
+<a href="https://www.iowacomputergurus.com/marketplace/open-source" target="_blank" class="CommandButton">Scheduled SQL Jobs is a free module provided by IowaComputerGurus Inc. (Donations Appreciated)</a>
 </p>


### PR DESCRIPTION
The link was evidently an older link and no redirect was in place.  Therefore, the link needed to be updated to the correct current link.